### PR TITLE
Update workshop 1-3 Colab notebooks to match tutorial docs

### DIFF
--- a/docs/colab/Introduction_Genomics_1_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_1_GoogleColab.ipynb
@@ -390,9 +390,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "To view the content of the file, we can use `zcat` to uncompress it and `head` to show the first lines. Using the shell this can be done in a single line (you will learn more about this in the Unix tutorial):"
-   ]
+   "source": "To view the content of the file, we can use `zcat` to uncompress it and `head` to show the first lines. Using the shell this can be done in a single line (you learnt about zcat in the unix tutorial, refer back to it for reference):"
   },
   {
    "cell_type": "code",
@@ -572,7 +570,7 @@
     "samtools tview bam/HepG2_directRNA_sample1_sorted.bam reference/hg38_chr22.fa\n",
     "```\n",
     "\n",
-    "*(Note: `samtools tview` is an interactive terminal viewer, shown here for reference only \u2014 it does not run well via `!` in a Colab cell without a TTY. Try it in a local/interactive shell, or use IGV / the UCSC Genome Browser below instead.)*\n",
+    "*(Note: `samtools tview` is an interactive terminal viewer, shown here for reference only — it does not run well via `!` in a Colab cell without a TTY. Try it in a local/interactive shell, or use IGV / the UCSC Genome Browser below instead.)*\n",
     "\n",
     "In order to navigate the alignment view, you can open the help by pressing `?`, which shows the following options (selected):\n",
     "\n",

--- a/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
@@ -61,7 +61,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### R\n\nBambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\nYou can check that R is installed correctly from the command line with:\n\n```bash\nR --version\n```"
+   "source": "### R\n\nBambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\nYou can check that R is installed correctly from the command line with:"
+  },
+  {
+   "cell_type": "code",
+   "source": "! R --version",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -116,19 +123,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "id": "tA7dGO9n1XSU"
    },
-   "outputs": [],
-   "source": [
-    "%%R\n",
-    "if (!require(\"BiocManager\", quietly = TRUE))\n",
-    "    install.packages(\"BiocManager\")\n",
-    "\n",
-    "BiocManager::install(\"bambu\", update=FALSE)"
-   ]
+   "source": "```\n%%R\nif (!require(\"BiocManager\", quietly = TRUE))\n    install.packages(\"BiocManager\")\n\nBiocManager::install(\"bambu\", update=FALSE)\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
@@ -127,7 +127,7 @@
    "metadata": {
     "id": "tA7dGO9n1XSU"
    },
-   "source": "```\n%%R\nif (!require(\"BiocManager\", quietly = TRUE))\n    install.packages(\"BiocManager\")\n\nBiocManager::install(\"bambu\", update=FALSE)\n```"
+   "source": "**Alternative: installing from within R.** Start R by entering `R` at the command line. At the R prompt, enter `if (!require(\"BiocManager\", quietly = TRUE)) install.packages(\"BiocManager\")`, followed by `BiocManager::install(\"bambu\", update = FALSE)`. On Colab, this looks like:\n\n```\n%%R\nif (!require(\"BiocManager\", quietly = TRUE))\n    install.packages(\"BiocManager\")\n\nBiocManager::install(\"bambu\", update=FALSE)\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
@@ -6,9 +6,7 @@
     "colab_type": "text",
     "id": "view-in-github"
    },
-   "source": [
-    "<a href=\"https://colab.research.google.com/github/GoekeLab/sg-nex-data/blob/master/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
+   "source": "<a href=\"https://colab.research.google.com/github/GoekeLab/sg-nex-data/blob/master/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
   },
   {
    "attachments": {},
@@ -24,38 +22,7 @@
     "\n",
     "This tutorial requires access to a shell (i.e. Linux, MacOS, or the Windows Subsystem for Linux/WSL). If you do not have access to any shell, you can run this tutorial on Google Colab by clicking the badge on top.\n",
     "\n",
-    "If you use Google Colab, you have to add `!` before any shell command to execute it in a subshell. Changing working directories requires to add `%` instead, which executes the command globally.\n",
-    "\n",
-    "\n",
-    "To execute R, you can run the following code:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext rpy2.ipython"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can now access R through Google Colab as illustrated with this small example code:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%R\n",
-    "x<-2\n",
-    "show(x^2)"
+    "If you use Google Colab, you have to add `!` before any shell command to execute it in a subshell. Changing working directories requires to add `%` instead, which executes the command globally. The R extension is loaded after the installation instructions below."
    ]
   },
   {
@@ -95,11 +62,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Bambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\n",
+    "### R\n",
     "\n",
+    "Bambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\n",
+    "You can check that R is installed correctly from the command line with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "! R --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "R is already installed on Google Colab.\n",
     "\n",
-    "[Bambu](https://github.com/GoekeLab/bambu) can be installed either through Github or through Bioconductor (recommended)"
+    "### Bioconductor and Bambu\n",
+    "\n",
+    "[Bambu](https://github.com/GoekeLab/bambu) can be installed either through conda or directly from within R. Installation is usually faster using conda."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Install bambu via conda (recommended)\n\nInstalling bambu through Bioconductor with `BiocManager::install()` can be slow or fail on Colab due to system library conflicts. Installing it via conda (from the bioconda channel) is more reliable.\n\n**Note:** `condacolab.install()` restarts the Colab runtime. After it restarts, re-run the cells below starting from the `mamba install` cell.\n\nThe `BiocManager::install(\"bambu\")` cell below is kept as a fallback in case the conda install doesn't work in your environment."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q condacolab\n",
+    "import condacolab\n",
+    "condacolab.install()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mamba install -c bioconda -c conda-forge bioconductor-bambu r-biocmanager -y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are using Google Colab, load its R extension after installing Bambu:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%load_ext rpy2.ipython"
    ]
   },
   {

--- a/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_2_GoogleColab.ipynb
@@ -61,21 +61,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### R\n",
-    "\n",
-    "Bambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\n",
-    "You can check that R is installed correctly from the command line with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "! R --version"
-   ]
+   "source": "### R\n\nBambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\nYou can check that R is installed correctly from the command line with:\n\n```bash\nR --version\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
@@ -159,7 +159,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### R\n\nBambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\nYou can check that R is installed correctly from the command line with:\n\n```bash\nR --version\n```"
+   "source": "### R\n\nBambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\nYou can check that R is installed correctly from the command line with:"
+  },
+  {
+   "cell_type": "code",
+   "source": "! R --version",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -214,19 +221,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "id": "n79n8SxRtH7A"
    },
-   "outputs": [],
-   "source": [
-    "%%R\n",
-    "if (!require(\"BiocManager\", quietly = TRUE))\n",
-    "    install.packages(\"BiocManager\")\n",
-    "\n",
-    "BiocManager::install(\"bambu\", update=FALSE)\n"
-   ]
+   "source": "```\n%%R\nif (!require(\"BiocManager\", quietly = TRUE))\n    install.packages(\"BiocManager\")\n\nBiocManager::install(\"bambu\", update=FALSE)\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
@@ -225,7 +225,7 @@
    "metadata": {
     "id": "n79n8SxRtH7A"
    },
-   "source": "```\n%%R\nif (!require(\"BiocManager\", quietly = TRUE))\n    install.packages(\"BiocManager\")\n\nBiocManager::install(\"bambu\", update=FALSE)\n```"
+   "source": "**Alternative: installing from within R.** Start R by entering `R` at the command line. At the R prompt, enter `if (!require(\"BiocManager\", quietly = TRUE)) install.packages(\"BiocManager\")`, followed by `BiocManager::install(\"bambu\", update = FALSE)`. On Colab, this looks like:\n\n```\n%%R\nif (!require(\"BiocManager\", quietly = TRUE))\n    install.packages(\"BiocManager\")\n\nBiocManager::install(\"bambu\", update=FALSE)\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
@@ -24,41 +24,7 @@
     "\n",
     "This tutorial requires access to a shell (i.e. Linux, MacOS, or the Windows Subsystem for Linux/WSL). If you do not have access to any shell, you can run this tutorial on Google Colab by clicking the badge on top.\n",
     "\n",
-    "If you use Google Colab, you have to add `!` before any shell command to execute it in a subshell. Changing working directories requires to add `%` instead, which executes the command globally."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To execute R, you can run the following line:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext rpy2.ipython"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "With this, you can access R through Google Colab as illustrated with this small example code:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%R\n",
-    "x<-2\n",
-    "show(x^2)"
+    "If you use Google Colab, you have to add `!` before any shell command to execute it in a subshell. Changing working directories requires to add `%` instead, which executes the command globally. The R extension is loaded after the installation instructions below."
    ]
   },
   {
@@ -194,9 +160,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Bambu** is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\n",
+    "### R\n",
     "\n",
-    "R is already installed on Google Colab. [Bambu](https://github.com/GoekeLab/bambu) can be installed either through Github or through Bioconductor (recommended). This step might take 30 minutes."
+    "Bambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\n",
+    "You can check that R is installed correctly from the command line with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "! R --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "R is already installed on Google Colab.\n",
+    "\n",
+    "### Bioconductor and Bambu\n",
+    "\n",
+    "[Bambu](https://github.com/GoekeLab/bambu) can be installed either through conda or directly from within R. Installation is usually faster using conda. This step might take 30 minutes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Install bambu via conda (recommended)\n\nInstalling bambu through Bioconductor with `BiocManager::install()` can be slow or fail on Colab due to system library conflicts. Installing it via conda (from the bioconda channel) is more reliable.\n\n**Note:** `condacolab.install()` restarts the Colab runtime. After it restarts, re-run the cells below starting from the `mamba install` cell.\n\nThe `BiocManager::install(\"bambu\")` cell below is kept as a fallback in case the conda install doesn't work in your environment."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q condacolab\n",
+    "import condacolab\n",
+    "condacolab.install()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mamba install -c bioconda -c conda-forge bioconductor-bambu r-biocmanager -y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are using Google Colab, load its R extension after installing Bambu:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%load_ext rpy2.ipython"
    ]
   },
   {
@@ -212,6 +240,23 @@
     "    install.packages(\"BiocManager\")\n",
     "\n",
     "BiocManager::install(\"bambu\", update=FALSE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can then run R code in a Colab cell using `%%R`, for example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%R\n",
+    "library(bambu)"
    ]
   },
   {
@@ -555,7 +600,7 @@
    "authorship_tag": "ABX9TyMlfODH3W+SfHeUvHzRzKkk",
    "collapsed_sections": [],
    "include_colab_link": true,
-   "name": "Introduction_Genomics_3_GoogleColab.ipynb",
+   "name": "Introduction_genomics_workflow.ipynb",
    "private_outputs": true,
    "provenance": []
   },

--- a/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
+++ b/docs/colab/Introduction_Genomics_3_GoogleColab.ipynb
@@ -159,21 +159,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### R\n",
-    "\n",
-    "Bambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\n",
-    "You can check that R is installed correctly from the command line with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "! R --version"
-   ]
+   "source": "### R\n\nBambu is a R package which requires a recent version of R (>4.0). Installation guidelines can be found online: <https://www.r-project.org/>\nYou can check that R is installed correctly from the command line with:\n\n```bash\nR --version\n```"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
Syncs the three RNA-Seq pipeline Colab notebooks (`docs/colab/Introduction_Genomics_1/2/3_GoogleColab.ipynb`) with the current DSA4262 tutorial markdown docs. Content-only changes to bring the notebooks up to date with the docs; no restructuring beyond what's needed to match.

**Workshop 1**
- AWS CLI install: `pip install awscli` → the current `curl`-based v2 installer
- Minimap2 `v2.26` → `v2.30` (download URL + symlink)
- Added the Minimap2/Samtools citations and missing section text (workshop directory purpose, genome/annotation download purpose, etc.) that the docs have but the notebook was missing
- Added a documentation-only `samtools tview` walkthrough (nav keys, example position) — kept as markdown rather than a runnable cell since `tview` is an interactive terminal viewer that doesn't behave well via `!` in Colab without a TTY
- Fixed the "Open in Colab" badge, which pointed at `nus-genomics/blob/master/2022/...` instead of this repo

**Workshop 2**
- Same AWS CLI fix
- Added the previously-missing "transcript discovery without annotations" (`NDR=1`) scenario — the notebook only had the "with annotations" run
- Filled in missing section documentation to match the docs, and reordered the install section (AWS before R/Bambu) and the "novel transcripts and genes" block (before, not after, the transcript-quantification section) to match the docs' order
- Updated the R/Bambu install section to match the docs' current conda-first flow: added an `R --version` check, reframed installation as conda-recommended with BiocManager-from-R as the documented alternative, and moved `%load_ext rpy2.ipython` to after the Bambu install (matching "load its R extension after installing Bambu"). Kept the existing `condacolab` + `mamba install` cells rather than transcribing the docs' generic `bash Miniforge3-...sh` instructions verbatim, since that doesn't work in a Colab cell (no persistent shell, needs a runtime restart) — added the missing `r-biocmanager` package to the `mamba install` line per the docs' troubleshooting note, and fixed a stale "re-run the cell above" reference after moving `%load_ext`
- Fixed the "Open in Colab" badge, which pointed at `nus-genomics/blob/master/DSA4266_2023/...` instead of this repo

**Workshop 3**
- Same AWS CLI fix, Minimap2 version bump, and R/Bambu install section update as workshop 2 (including adding the `%%R library(bambu)` load-test the docs show, which this notebook didn't have)
- Removed a duplicated "list runs / clean -n / clean -f" cycle in the "Clean working directories" section (was run twice; the docs only show it once)
- Dropped a duplicate "Using Google Colab" block that repeated the intro cell

## Test plan
- [ ] Validated all three notebooks as well-formed JSON before pushing
- [ ] Open each notebook in Colab and run top-to-bottom to confirm the conda/Bambu install flow and reordered cells still execute correctly
